### PR TITLE
Add support for shell command in install hooks

### DIFF
--- a/pkg/apps/helm/helm.go
+++ b/pkg/apps/helm/helm.go
@@ -95,7 +95,7 @@ func helmCommand(m method, name, version, namespace, chart string) (string, erro
 		c.Args = append(c.Args, "--version", version)
 	}
 	if m == installMethod {
-		c.Args = append(c.Args, "--wait")
+		c.Args = append(c.Args, "--wait", "--create-namespace")
 	}
 	out, err := c.CombinedOutput()
 	return string(out), err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,14 +21,14 @@ type AppConfig struct {
 }
 
 type App struct {
-	Repository  Repository  `yaml:"repository"`
-	Name        string      `yaml:"name"`
-	Namespace   string      `yaml:"namespace"`
-	URL         string      `yaml:"url"`
-	SHA256      string      `yaml:"sha256"`
-	Version     string      `yaml:"version"`
-	PreInstall  PreInstall  `yaml:"pre_install"`
-	PostInstall PostInstall `yaml:"post_install"`
+	Repository  Repository    `yaml:"repository"`
+	Name        string        `yaml:"name"`
+	Namespace   string        `yaml:"namespace"`
+	URL         string        `yaml:"url"`
+	SHA256      string        `yaml:"sha256"`
+	Version     string        `yaml:"version"`
+	PreInstall  []PreInstall  `yaml:"pre_install"`
+	PostInstall []PostInstall `yaml:"post_install"`
 }
 
 type Repository struct {
@@ -38,11 +38,13 @@ type Repository struct {
 }
 
 type PreInstall struct {
-	Apps []string
+	Apps  []string
+	Steps []string
 }
 
 type PostInstall struct {
-	Apps []string
+	Apps  []string
+	Steps []string
 }
 
 func New(path string) (*AppConfig, error) {

--- a/testdata/zookeeper-operator.yaml
+++ b/testdata/zookeeper-operator.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: kbrew
+app:
+  repository:
+    name: pravega
+    url: https://charts.pravega.io
+    type: helm
+  name: zookeeper-operator
+  namespace: zookeeper
+  sha256:
+  version: 
+  post_install:
+  - steps: 
+    - |
+      kubectl create --namespace zookeeper -f - <<EOF
+      apiVersion: zookeeper.pravega.io/v1beta1
+      kind: ZookeeperCluster
+      metadata:
+          name: zookeeper
+          namespace: zookeeper
+      spec:
+          replicas: 3
+      EOF
+    - |
+      echo "Waiting for zookeeper cluster to be ready"
+      retry=0
+      while true;
+      do
+      replicas=$(kubectl get ZookeeperCluster -n zookeeper zookeeper -o jsonpath='{.status.replicas}')
+      readyReplicas=$(kubectl get ZookeeperCluster -n zookeeper zookeeper -o jsonpath='{.status.readyReplicas}')
+      if [ ! -z "${replicas}" ] && [ "${replicas}" = "${readyReplicas}" ]; then break; fi
+      if [ "${retry}" = 20 ]; then echo "timed out while waiting for cluster to be ready"; exit 1; fi
+      sleep 5
+      retry=$((retry+1))
+      done


### PR DESCRIPTION
### Sample config file:
```
apiVersion: v1
kind: kbrew
app:
  repository:
    name: pravega
    url: https://charts.pravega.io
    type: helm
  name: zookeeper-operator
  namespace: zookeeper
  sha256:
  version: 
  post_install:
  - steps: 
    - |
      kubectl create --namespace zookeeper -f - <<EOF
      apiVersion: zookeeper.pravega.io/v1beta1
      kind: ZookeeperCluster
      metadata:
          name: zookeeper
          namespace: zookeeper
      spec:
          replicas: 3
      EOF
    - |
      echo "Waiting for zookeeper cluster to be ready"
      retry=0
      while true;
      do
      replicas=$(kubectl get ZookeeperCluster -n zookeeper zookeeper -o jsonpath='{.status.replicas}')
      readyReplicas=$(kubectl get ZookeeperCluster -n zookeeper zookeeper -o jsonpath='{.status.readyReplicas}')
      if [ ! -z "${replicas}" ] && [ "${replicas}" = "${readyReplicas}" ]; then break; fi
      if [ "${retry}" = 20 ]; then echo "timed out while waiting for cluster to be ready"; exit 1; fi
      sleep 5
      retry=$((retry+1))
      done
```

### Installation example:
```
$ kbrew install --config testdata/zookeeper-operator.yaml zookeeper-operator
Installing helm app pravega/zookeeper-operator
NAME: zookeeper-operator
LAST DEPLOYED: Tue Mar  2 11:27:41 2021
NAMESPACE: zookeeper
STATUS: deployed
REVISION: 1
TEST SUITE: None

zookeepercluster.zookeeper.pravega.io/zookeeper created
Waiting for zookeeper cluster to be ready
```