### PR TITLE
Add recipe for kafka operator installation

### DIFF
--- a/pkg/apps/raw/raw.go
+++ b/pkg/apps/raw/raw.go
@@ -69,6 +69,7 @@ func New(c config.App) (*RawApp, error) {
 }
 
 func (r *RawApp) Install(ctx context.Context, name, namespace, version string, options map[string]string) error {
+	fmt.Printf("Installing raw app %s/%s\n", r.App.Repository.Name, name)
 	// TODO(@prasad): Use go sdks
 	if err := kubectlCommand(install, name, namespace, r.App.Repository.URL); err != nil {
 		return err
@@ -77,6 +78,7 @@ func (r *RawApp) Install(ctx context.Context, name, namespace, version string, o
 }
 
 func (r *RawApp) Uninstall(ctx context.Context, name, namespace string) error {
+	fmt.Printf("Unistalling raw app %s\n", name)
 	// TODO(@prasad): Use go sdks
 	return kubectlCommand(uninstall, name, namespace, r.App.Repository.URL)
 }

--- a/recipes/cert-manager.yaml
+++ b/recipes/cert-manager.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: kbrew
+app:
+  repository:
+    name: cert-manager
+    url: https://github.com/jetstack/cert-manager/releases/download/v0.10.1/cert-manager.yaml
+    type: raw
+  name: cert-manager
+  namespace: "-"
+  sha256:
+  version: v0.10.1
+  pre_install:
+    steps:
+    - kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.10.1/deploy/manifests/01-namespace.yaml

--- a/recipes/kafka-operator.yaml
+++ b/recipes/kafka-operator.yaml
@@ -1,0 +1,51 @@
+# https://banzaicloud.com/docs/supertubes/kafka-operator/install-kafka-operator/
+apiVersion: v1
+kind: kbrew
+app:
+  repository:
+    name: banzaicloud-stable
+    url: https://kubernetes-charts.banzaicloud.com
+    type: helm
+  name: kafka-operator
+  namespace: kafka
+  sha256:
+  version: 
+  pre_install:
+  - apps:
+    - cert-manager
+    - zookeeper-operator
+    - kube-prometheus-stack
+  - steps: 
+      # Create a Zookeeper cluster
+      - |
+        kubectl apply --namespace zookeeper -f - <<EOF
+        apiVersion: zookeeper.pravega.io/v1beta1
+        kind: ZookeeperCluster
+        metadata:
+            name: zookeeper
+            namespace: zookeeper
+        spec:
+            replicas: 3
+        EOF
+      # Wait for Zookeeper cluster to be ready
+      - |
+        echo "Waiting for zookeeper cluster to be ready"
+        retry=0
+        while true;
+        do
+          replicas=$(kubectl get ZookeeperCluster -n zookeeper zookeeper -o jsonpath='{.status.replicas}')
+          readyReplicas=$(kubectl get ZookeeperCluster -n zookeeper zookeeper -o jsonpath='{.status.readyReplicas}')
+          if [ ! -z "${replicas}" ] && [ "${replicas}" = "${readyReplicas}" ]; then break; fi
+          if [ "${retry}" = 20 ]; then echo "timed out while waiting for cluster to be ready"; exit 1; fi
+          sleep 5
+          retry=$((retry+1))
+        done
+  # Install the kafka-operator CustomResourceDefinition 
+  - steps:
+    - kubectl apply --validate=false -f https://github.com/banzaicloud/kafka-operator/releases/download/v0.14.0/kafka-operator.crds.yaml
+  post_install:
+  - steps:
+    # Add your zookeeper service name to the configuration.
+    - kubectl apply -n kafka -f https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/config/samples/simplekafkacluster.yaml
+    # Create the prometheus ServiceMonitors.
+    - kubectl apply -n kafka -f https://raw.githubusercontent.com/banzaicloud/kafka-operator/master/config/samples/kafkacluster-prometheus.yaml

--- a/recipes/kube-prometheus-stack.yaml
+++ b/recipes/kube-prometheus-stack.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: kbrew
+app:
+  repository:
+    name: prometheus-community
+    url: https://prometheus-community.github.io/helm-charts
+    type: helm
+  name: kube-prometheus-stack
+  namespace: default
+  sha256:
+  version: 

--- a/recipes/zookeeper-operator.yaml
+++ b/recipes/zookeeper-operator.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: kbrew
+app:
+  repository:
+    name: pravega
+    url: https://charts.pravega.io
+    type: helm
+  name: zookeeper-operator
+  namespace: zookeeper
+  sha256:
+  version: 


### PR DESCRIPTION
### Usage:
```
$ kbrew install --config=./recipes/kafka-operator.yaml kafka-operator
Installing raw app cert-manager/cert-manager
customresourcedefinition.apiextensions.k8s.io/certificaterequests.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/certificates.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/challenges.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/clusterissuers.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/issuers.certmanager.k8s.io created
customresourcedefinition.apiextensions.k8s.io/orders.certmanager.k8s.io created
namespace/cert-manager created
serviceaccount/cert-manager-cainjector created
serviceaccount/cert-manager created
serviceaccount/cert-manager-webhook created
clusterrole.rbac.authorization.k8s.io/cert-manager-cainjector created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-cainjector created
clusterrole.rbac.authorization.k8s.io/cert-manager-leaderelection created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-issuers created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-certificates created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-orders created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-challenges created
clusterrole.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-leaderelection created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-issuers created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-clusterissuers created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-certificates created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-orders created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-challenges created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-controller-ingress-shim created
clusterrole.rbac.authorization.k8s.io/cert-manager-view created
clusterrole.rbac.authorization.k8s.io/cert-manager-edit created
clusterrolebinding.rbac.authorization.k8s.io/cert-manager-webhook:auth-delegator created
rolebinding.rbac.authorization.k8s.io/cert-manager-webhook:webhook-authentication-reader created
clusterrole.rbac.authorization.k8s.io/cert-manager-webhook:webhook-requester created
service/cert-manager created
service/cert-manager-webhook created
deployment.apps/cert-manager-cainjector created
deployment.apps/cert-manager created
deployment.apps/cert-manager-webhook created
apiservice.apiregistration.k8s.io/v1beta1.webhook.certmanager.k8s.io created
mutatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
validatingwebhookconfiguration.admissionregistration.k8s.io/cert-manager-webhook created
Installing helm app pravega/zookeeper-operator
NAME: zookeeper-operator
LAST DEPLOYED: Wed Mar  3 15:07:13 2021
NAMESPACE: zookeeper
STATUS: deployed
REVISION: 1
TEST SUITE: None

Installing helm app prometheus-community/kube-prometheus-stack
NAME: kube-prometheus-stack
LAST DEPLOYED: Wed Mar  3 15:09:05 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
kube-prometheus-stack has been installed. Check its status by running:
  kubectl --namespace default get pods -l "release=kube-prometheus-stack"

Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how to create & configure Alertmanager and Prometheus instances using the Operator.

zookeepercluster.zookeeper.pravega.io/zookeeper created
Waiting for zookeeper cluster to be ready
customresourcedefinition.apiextensions.k8s.io/kafkatopics.kafka.banzaicloud.io configured
customresourcedefinition.apiextensions.k8s.io/kafkaclusters.kafka.banzaicloud.io configured
customresourcedefinition.apiextensions.k8s.io/kafkausers.kafka.banzaicloud.io configured
Installing helm app banzaicloud-stable/kafka-operator
NAME: kafka-operator
LAST DEPLOYED: Wed Mar  3 15:16:29 2021
NAMESPACE: kafka
STATUS: deployed
REVISION: 1
TEST SUITE: None

kafkacluster.kafka.banzaicloud.io/kafka created
servicemonitor.monitoring.coreos.com/kafka-servicemonitor created
servicemonitor.monitoring.coreos.com/cruisecontrol-servicemonitor created
prometheusrule.monitoring.coreos.com/kafka-alerts created
serviceaccount/prometheus created
clusterrole.rbac.authorization.k8s.io/prometheus created
clusterrolebinding.rbac.authorization.k8s.io/prometheus created
prometheus.monitoring.coreos.com/kafka-prometheus created

```