### PR TITLE
Add support to update kbrew registries

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -83,8 +83,16 @@ var (
 		Use:   "update",
 		Short: "Update kbrew and recipe registries",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO(@prasad): Update kbrew registries
-			return update.CheckRelease(context.Background())
+			// Upgrade kbrew
+			if err := update.CheckRelease(context.Background()); err != nil {
+				return err
+			}
+			// Update kbrew registries
+			reg, err := registry.New(config.ConfigDir)
+			if err != nil {
+				return err
+			}
+			return reg.Update()
 		},
 	}
 )

--- a/pkg/update/updater.go
+++ b/pkg/update/updater.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kbrew-dev/kbrew/pkg/version"
 
 	"github.com/google/go-github/v27/github"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -30,8 +31,7 @@ func CheckRelease(ctx context.Context) error {
 	client := github.NewClient(nil)
 	release, _, err := client.Repositories.GetLatestRelease(ctx, releaseRepoOwner, releaseRepoName)
 	if err != nil {
-		fmt.Println("Failed to check for kbrew updates.")
-		return err
+		return errors.Wrap(err, "failed to check for kbrew updates")
 	}
 	if release == nil || release.TagName == nil {
 		return nil
@@ -47,8 +47,7 @@ func CheckRelease(ctx context.Context) error {
 func upgradeKbrew(ctx context.Context) error {
 	dir, err := getBinDir()
 	if err != nil {
-		fmt.Println("Failed to get executable dir.")
-		return err
+		return errors.Wrap(err, "failed to get executable dir")
 	}
 	os.Setenv("BINDIR", dir)
 	defer os.Unsetenv("BINDIR")


### PR DESCRIPTION
```
$ kbrew update
kbrew v0.0.1 is available, upgrading...
kbrew-dev/kbrew-release info checking GitHub for latest tag
kbrew-dev/kbrew-release info found version: 0.0.1 for v0.0.1/Linux/x86_64
kbrew-dev/kbrew-release info installed /home/prasad/go-ws/bin/kbrew
Adding kbrew-dev/kbrew-registry registry to /home/prasad/.kbrew/registries
Registry kbrew-dev/kbrew-registry head at d020a5c5fcf10f56ff87ffd9d92072cbe1954c10 refs/heads/main
Fetching updates for registry kbrew-dev/kbrew-registry
Registry kbrew-dev/kbrew-registry head is set to d020a5c5fcf10f56ff87ffd9d92072cbe1954c10 refs/heads/main
```