### PR TITLE
change args value to empty interface

### DIFF
--- a/pkg/apps/helm/helm.go
+++ b/pkg/apps/helm/helm.go
@@ -78,7 +78,7 @@ func (ha *App) resolveArgs() error {
 	// TODO(@sahil.lakhwani): Parse only templated arguments
 	if len(ha.App.Args) != 0 {
 		for arg, value := range ha.App.Args {
-			v, err := e.Render(value)
+			v, err := e.Render(fmt.Sprintf("%v", value))
 			if err != nil {
 				return err
 			}
@@ -121,7 +121,7 @@ func (ha *App) Search(ctx context.Context, name string) (string, error) {
 	return string(out), err
 }
 
-func helmCommand(m method, name, version, namespace, chart string, chartArgs map[string]string) (string, error) {
+func helmCommand(m method, name, version, namespace, chart string, chartArgs map[string]interface{}) (string, error) {
 	// Needs helm 3.2+
 	c := exec.Command("helm", string(m), name, "--namespace", namespace)
 	if chart != "" {
@@ -142,10 +142,10 @@ func helmCommand(m method, name, version, namespace, chart string, chartArgs map
 	return string(out), err
 }
 
-func appendChartArgs(args map[string]string) []string {
+func appendChartArgs(args map[string]interface{}) []string {
 	var s []string
 	for k, v := range args {
-		s = append(s, "--set", k+"="+v)
+		s = append(s, "--set", k+"="+fmt.Sprintf("%s", v))
 	}
 	return s
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,15 +34,15 @@ type AppConfig struct {
 
 // App hold app details set in kbrew recipe
 type App struct {
-	Args        map[string]string `yaml:"args"`
-	Repository  Repository        `yaml:"repository"`
-	Name        string            `yaml:"name"`
-	Namespace   string            `yaml:"namespace"`
-	URL         string            `yaml:"url"`
-	SHA256      string            `yaml:"sha256"`
-	Version     string            `yaml:"version"`
-	PreInstall  []PreInstall      `yaml:"pre_install"`
-	PostInstall []PostInstall     `yaml:"post_install"`
+	Args        map[string]interface{} `yaml:"args"`
+	Repository  Repository             `yaml:"repository"`
+	Name        string                 `yaml:"name"`
+	Namespace   string                 `yaml:"namespace"`
+	URL         string                 `yaml:"url"`
+	SHA256      string                 `yaml:"sha256"`
+	Version     string                 `yaml:"version"`
+	PreInstall  []PreInstall           `yaml:"pre_install"`
+	PostInstall []PostInstall          `yaml:"post_install"`
 }
 
 // Repository is the repo for kbrew app


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

The `Args` field in App is currently `map[string]string`, so values always are `string` type`. This may post challenges in the code where the actual type of the argument value is needed.

Changing it to empty `map[string]interfcae{}` so that the code can type assert it to the actual type.

Have tested kbrew helm installations with args after this change.