### PR TITLE
Support custom wait-for-ready timeout

### DIFF
--- a/pkg/apps/raw/raw.go
+++ b/pkg/apps/raw/raw.go
@@ -90,7 +90,7 @@ func (r *App) Install(ctx context.Context, name, namespace, version string, opti
 	}
 
 	// TODO(@prasad): Use go sdks
-	if err := kubectlCommand(install, name, namespace, patchedManifest); err != nil {
+	if err := kubectlCommand(ctx, install, name, namespace, patchedManifest); err != nil {
 		return err
 	}
 	return r.waitForReady(ctx, namespace)
@@ -100,7 +100,7 @@ func (r *App) Install(ctx context.Context, name, namespace, version string, opti
 func (r *App) Uninstall(ctx context.Context, name, namespace string) error {
 	fmt.Printf("Unistalling raw app %s\n", name)
 	// TODO(@prasad): Use go sdks
-	return kubectlCommand(uninstall, name, namespace, r.App.Repository.URL)
+	return kubectlCommand(ctx, uninstall, name, namespace, r.App.Repository.URL)
 }
 
 // Search searches the app specified by name.
@@ -108,15 +108,15 @@ func (r *App) Search(ctx context.Context, name string) (string, error) {
 	return printList(r.App), nil
 }
 
-func kubectlCommand(m method, name, namespace, manifest string) error {
+func kubectlCommand(ctx context.Context, m method, name, namespace, manifest string) error {
 	var c *exec.Cmd
 	switch m {
 	case install:
-		c = exec.Command("kubectl", string(m), "-f", "-")
+		c = exec.CommandContext(ctx, "kubectl", string(m), "-f", "-")
 		// Pass the manifest on STDIN
 		c.Stdin = strings.NewReader(manifest)
 	default:
-		c = exec.Command("kubectl", string(m), "-f", manifest)
+		c = exec.CommandContext(ctx, "kubectl", string(m), "-f", manifest)
 	}
 
 	if namespace != "" {

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -2,39 +2,28 @@ package kube
 
 import (
 	"context"
-	"time"
 
 	"github.com/kanisterio/kanister/pkg/kube"
 	osversioned "github.com/openshift/client-go/apps/clientset/versioned"
 	"k8s.io/client-go/kubernetes"
 )
 
-const workloadReadyTimeout = 15 * time.Minute
-
 // WaitForPodReady waits till the pod gets ready
 func WaitForPodReady(ctx context.Context, kubeCli kubernetes.Interface, namespace string, name string) error {
-	ctx, cancel := context.WithTimeout(ctx, workloadReadyTimeout)
-	defer cancel()
 	return kube.WaitForPodReady(ctx, kubeCli, namespace, name)
 }
 
 // WaitForDeploymentReady waits till the deployment gets ready
 func WaitForDeploymentReady(ctx context.Context, kubeCli kubernetes.Interface, namespace string, name string) error {
-	ctx, cancel := context.WithTimeout(ctx, workloadReadyTimeout)
-	defer cancel()
 	return kube.WaitOnDeploymentReady(ctx, kubeCli, namespace, name)
 }
 
 // WaitForStatefulSetReady waits till the statefulset gets ready
 func WaitForStatefulSetReady(ctx context.Context, kubeCli kubernetes.Interface, namespace string, name string) error {
-	ctx, cancel := context.WithTimeout(ctx, workloadReadyTimeout)
-	defer cancel()
 	return kube.WaitOnStatefulSetReady(ctx, kubeCli, namespace, name)
 }
 
 // WaitForDeploymentConfigReady waits till the deployment config gets ready
 func WaitForDeploymentConfigReady(ctx context.Context, osCli osversioned.Interface, kubeCli kubernetes.Interface, namespace string, name string) error {
-	ctx, cancel := context.WithTimeout(ctx, workloadReadyTimeout)
-	defer cancel()
 	return kube.WaitOnDeploymentConfigReady(ctx, osCli, kubeCli, namespace, name)
 }


### PR DESCRIPTION
- Add new flag `--timeout` to override default timeout
- Use consistent timeout for raw and helm apps

#### Example:
```
$ kbrew install mysql --timeout 10m
```
Fixes: #75 