### PR TITLE
Silence usage and error print

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -26,9 +26,11 @@ var (
 	timeout    string
 
 	rootCmd = &cobra.Command{
-		Use:   "kbrew",
-		Short: "Homebrew for your Kubernetes applications",
-		Long:  `TODO: Long description`,
+		Use:           "kbrew",
+		Short:         "Homebrew for your Kubernetes applications",
+		Long:          `TODO: Long description`,
+		SilenceErrors: true,
+		SilenceUsage:  true,
 	}
 
 	versionCmd = &cobra.Command{


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

Currently in case of error for commands, the cli outputs the usage - `SilenceUsage` is to avoid that

The error is being printed twice - `SilenceErrors` so that the error is printed only once at [here](https://github.com/kbrew-dev/kbrew/blob/254ab65e8c6963cb2f2871e4a5eb41ec0f58be52/cmd/cli/main.go#L164)