### PR TITLE
render templates before unmarshalling

### DIFF
--- a/pkg/apps/helm/helm.go
+++ b/pkg/apps/helm/helm.go
@@ -8,11 +8,9 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kbrew-dev/kbrew/pkg/apps/raw"
 	"github.com/kbrew-dev/kbrew/pkg/config"
-	"github.com/kbrew-dev/kbrew/pkg/engine"
 	"github.com/kbrew-dev/kbrew/pkg/log"
 )
 
@@ -74,25 +72,11 @@ func (ha *App) Uninstall(ctx context.Context, name, namespace string) error {
 }
 
 func (ha *App) resolveArgs() error {
-	//TODO: user global singleton kubeconfig in all modules
-	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		&clientcmd.ConfigOverrides{},
-	).ClientConfig()
-	if err != nil {
-		return errors.Wrapf(err, "Failed to load Kubernetes config")
-	}
-
-	e := engine.NewEngine(config)
-
-	// TODO(@sahil.lakhwani): Parse only templated arguments
 	if len(ha.app.Args) != 0 {
 		for arg, value := range ha.app.Args {
-			v, err := e.Render(fmt.Sprintf("%v", value))
-			if err != nil {
-				return err
+			if value == nil {
+				ha.app.Args[arg] = ""
 			}
-			ha.app.Args[arg] = v
 		}
 	}
 	return nil

--- a/pkg/apps/raw/raw.go
+++ b/pkg/apps/raw/raw.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kbrew-dev/kbrew/pkg/config"
-	"github.com/kbrew-dev/kbrew/pkg/engine"
 	"github.com/kbrew-dev/kbrew/pkg/kube"
 	"github.com/kbrew-dev/kbrew/pkg/log"
 	"github.com/kbrew-dev/kbrew/pkg/yaml"
@@ -80,39 +79,10 @@ func New(c config.App, log *log.Logger) (*App, error) {
 	return rApp, nil
 }
 
-func (r *App) resolveArgs() error {
-	//TODO: user global singleton kubeconfig in all modules
-	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		&clientcmd.ConfigOverrides{},
-	).ClientConfig()
-	if err != nil {
-		return errors.Wrapf(err, "Failed to load Kubernetes config")
-	}
-
-	e := engine.NewEngine(config)
-
-	// TODO(@sahil.lakhwani): Parse only templated arguments
-	if len(r.app.Args) != 0 {
-		for arg, value := range r.app.Args {
-			v, err := e.Render(fmt.Sprintf("%v", value))
-			if err != nil {
-				return err
-			}
-			r.app.Args[arg] = v
-		}
-	}
-	return nil
-}
-
 // Install installs the app specified by name, version and namespace.
 func (r *App) Install(ctx context.Context, name, namespace, version string, options map[string]string) error {
 	manifest, err := getManifest(r.app.Repository.URL)
 	if err != nil {
-		return err
-	}
-
-	if err := r.resolveArgs(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

Unmarshalling recipe YAML and then rendering Go template converts everything to strings and actual data types are lost. This PR renders the Go templates and then unmarshalls it to `AppConfig`